### PR TITLE
Use Webpack 4 for create-next-app

### DIFF
--- a/create-next-app-webpack-5/next.config.js
+++ b/create-next-app-webpack-5/next.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  future: {
-    webpack5: true,
-  },
-}

--- a/create-next-app/next.config.js
+++ b/create-next-app/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  webpack: (config) => {
+    // Important: return the modified config
+    return config;
+  },
+};


### PR DESCRIPTION
I noticed while testing `create-next-app` that it uses Webpack 5. Since we already have a project called `create-next-app-webpack-5`, I'm assuming this project is supposed to test the functionality of Webpack 4. The latest version of Next defaults to Webpack 5 unless a custom Webpack configuration is specified, so I've added one to the project and deleted the `nuxt.config.js` inside `create-next-app-webpack-5`. Since Webpack 5 is the default for the latest version of Next, maybe the project structure should be changed to
* `create-next-app` -> `create-next-app-webpack-4`
* `create-next-app-webpack-5` -> `create-next-app`

Before
![Screen Shot 2021-09-07 at 12 57 13 PM](https://user-images.githubusercontent.com/25158820/132390544-561a3058-a3e4-41f1-af11-6704149b86f8.png)
After
![Screen Shot 2021-09-07 at 12 57 41 PM](https://user-images.githubusercontent.com/25158820/132390548-c2092aad-ed0b-4a04-9565-76e199d467c1.png)
